### PR TITLE
fix destroy and recreate nodes on 'terraform apply' 

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -34,7 +34,7 @@ data "template_file" "rancher-install" {
 /* Give us access to the VPC that we're configured for */
 data "aws_vpc" "vpc" {
   filter {
-    name = "tag:Environment"
+    name   = "tag:Environment"
     values = ["${var.environment}"]
   }
 }

--- a/elb.tf
+++ b/elb.tf
@@ -1,17 +1,16 @@
 resource "aws_elb" "rancher" {
-  name                = "${var.environment}-rancher-elb"
-  security_groups     = ["${aws_security_group.elb.id}"]
-  subnets             = ["${data.aws_subnet_ids.public.ids}"]
-  instances           = ["${aws_instance.rancher.*.id}"]
+  name            = "${var.environment}-rancher-elb"
+  security_groups = ["${aws_security_group.elb.id}"]
+  subnets         = ["${data.aws_subnet_ids.public.ids}"]
+  instances       = ["${aws_instance.rancher.*.id}"]
 
   listener {
-    instance_port       = 8080
-    instance_protocol   = "tcp"
-    lb_port             = 443
-    lb_protocol         = "ssl"
-    ssl_certificate_id  = "${var.acm_ssl_cert_arn}"
+    instance_port      = 8080
+    instance_protocol  = "tcp"
+    lb_port            = 443
+    lb_protocol        = "ssl"
+    ssl_certificate_id = "${var.acm_ssl_cert_arn}"
   }
-
 }
 
 resource "aws_proxy_protocol_policy" "websockets" {

--- a/mysql.tf
+++ b/mysql.tf
@@ -11,8 +11,8 @@ resource "aws_db_instance" "rancher" {
   parameter_group_name   = "default.mysql5.7"
   vpc_security_group_ids = ["${aws_security_group.mysql-server.id}"]
   storage_type           = "gp2"
-  skip_final_snapshot     = true
-  multi_az              = "${var.multi_az}"
+  skip_final_snapshot    = true
+  multi_az               = "${var.multi_az}"
 }
 
 resource "aws_db_subnet_group" "rancher" {

--- a/rancher-cluster.tf
+++ b/rancher-cluster.tf
@@ -1,11 +1,11 @@
 resource "aws_instance" "rancher" {
-  count           = "${var.rancher_cluster_size}"
-  ami             = "${data.aws_ami.rancher-server.id}"
-  instance_type   = "${var.rancher_server_instance_type}"
-  key_name        = "${var.key_name}"
-  security_groups = ["${aws_security_group.rancher-server.id}"]
-  subnet_id       = "${element(data.aws_subnet_ids.private.ids, count.index)}"
-  user_data       = "${data.template_file.rancher-install.rendered}"
+  count                  = "${var.rancher_cluster_size}"
+  ami                    = "${data.aws_ami.rancher-server.id}"
+  instance_type          = "${var.rancher_server_instance_type}"
+  key_name               = "${var.key_name}"
+  vpc_security_group_ids = ["${aws_security_group.rancher-server.id}"]
+  subnet_id              = "${element(data.aws_subnet_ids.private.ids, count.index)}"
+  user_data              = "${data.template_file.rancher-install.rendered}"
 
   tags {
     Name = "rancher-server"

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,7 @@ variable "master_username" {
 
 variable "multi_az" {
   description = "Whether you want your database to be configured as Multi-AZ"
-  default = false
+  default     = false
 }
 
 variable "rancher_server_version" {


### PR DESCRIPTION
This is caused by the `vpc_security_group_ids` didn't set and the `security_groups` param always checks the id of nodes everytime '`terraform apply`' execute.